### PR TITLE
Fix using deprecated `URI.encode`

### DIFF
--- a/src/policy/html_sanitizer.cr
+++ b/src/policy/html_sanitizer.cr
@@ -266,7 +266,9 @@ class Sanitize::Policy::HTMLSanitizer < Sanitize::Policy::Whitelist
     # Make sure special characters are properly encoded to avoid interpretation
     # of tweaked relative paths as "javascript:" URI (for example)
     if path = uri.path
-      uri.path = URI.encode(URI.decode(path))
+      uri.path = String.build do |io|
+        URI.encode(URI.decode(path), io) { |byte| URI.reserved?(byte) || URI.unreserved?(byte) }
+      end
     end
 
     uri.to_s


### PR DESCRIPTION
For our use case of encoding an *entire* URI we need an implementation with a custom block. The old implementation has been deprecated in Crystal 1.2.0 (https://github.com/crystal-lang/crystal/pull/11248).

Resolves #2