### PR TITLE
Fix compatibility with libxml2 2.9.13

### DIFF
--- a/spec/html_sanitizer/basic.hrx
+++ b/spec/html_sanitizer/basic.hrx
@@ -50,7 +50,7 @@ Lorem <a href="pants" title="foo&gt;ipsum &lt;a href=" rel="nofollow"><strong>do
 
 
 <===> malicious/fragment.html
-<b>Lo<!-- comment -->rem</b> <a href="javascript:pants" title="foo">ipsum</a> <a href="http://foo.com/"><strong>dolor</strong></a> sit<br/>amet <<foo>script>alert("hello world");</script>
+<b>Lo<!-- comment -->rem</b> <a href="javascript:pants" title="foo">ipsum</a> <a href="http://foo.com/"><strong>dolor</strong></a> sit<br/>amet &lt;script>alert("hello world");</script>
 <===> malicious/common.html
 <b>Lorem</b> ipsum <a href="http://foo.com/" rel="nofollow"><strong>dolor</strong></a> sit<br/>amet &lt;script&gt;alert(&quot;hello world&quot;);
 <===>

--- a/spec/html_sanitizer/combined_policies.hrx
+++ b/spec/html_sanitizer/combined_policies.hrx
@@ -32,7 +32,7 @@ a b
 
 
 <===> malicious/fragment.html
-<b>Lo<!-- comment -->rem</b> <a href="javascript:pants" title="foo">ipsum</a> <a href="http://foo.com/"><strong>dolor</strong></a> sit<br/>amet <<foo>script>alert("hello world");</script>
+<b>Lo<!-- comment -->rem</b> <a href="javascript:pants" title="foo">ipsum</a> <a href="http://foo.com/"><strong>dolor</strong></a> sit<br/>amet &lt;script>alert("hello world");</script>
 <===> malicious/text.html
 Lorem ipsum dolor sit amet &lt;script&gt;alert(&quot;hello world&quot;);
 <===> malicious/inline.html

--- a/spec/html_sanitizer/xss.hrx
+++ b/spec/html_sanitizer/xss.hrx
@@ -6,9 +6,10 @@ test
 <===>
 
 
-<===> fragment.html
+# Pending because libxml2 behaviour changed in 2.9.13 (https://gitlab.gnome.org/GNOME/libxml2/-/issues/339)
+<===> pending:fragment.html
 <<<><<script src=http://fake-evil.ru/test.js>
-<===> common.html
+<===> pending:common.html
 &lt;&lt;&lt;&gt;&lt;
 <===>
 

--- a/spec/text_policy.hrx
+++ b/spec/text_policy.hrx
@@ -47,9 +47,10 @@ Lorem ipsum dolor sit amet
 <==>
 
 
-<==> html-special-chars/fragment.html
+# Pending because libxml2 behaviour changed in 2.9.13 (https://gitlab.gnome.org/GNOME/libxml2/-/issues/339)
+<==> pending:html-special-chars/fragment.html
 <<foo>script>
-<==> html-special-chars/text.html
+<==> pending:html-special-chars/text.html
 &lt;script&gt;
 <==>
 


### PR DESCRIPTION
libxml2 2.9.13 changed behaviour of parsing a bare `<` character (https://gitlab.gnome.org/GNOME/libxml2/-/issues/339)