### PR TITLE
Add expectations for specific libxml2 versions

### DIFF
--- a/spec/html_sanitizer/xss.hrx
+++ b/spec/html_sanitizer/xss.hrx
@@ -6,10 +6,14 @@ test
 <===>
 
 
-# Pending because libxml2 behaviour changed in 2.9.13 (https://gitlab.gnome.org/GNOME/libxml2/-/issues/339)
-<===> pending:fragment.html
+# libxml2 behaviour changed in 2.9.13 (https://gitlab.gnome.org/GNOME/libxml2/-/issues/339)
+<===> fragment.html
 <<<><<script src=http://fake-evil.ru/test.js>
-<===> pending:common.html
+<===> libxml2>2.9.13:common.html
+&lt;&lt;&lt;&gt;&lt;
+<===> libxml2==2.9.13:common.html
+
+<===> libxml2<2.9.13:common.html
 &lt;&lt;&lt;&gt;&lt;
 <===>
 
@@ -430,15 +434,19 @@ text
 
 <===> fragment.html
 <div>text <!--[if IE]> <!--[if gte 6]> comment <[endif]--><[endif]--></div>
-<===> common.html
+<===> libxml2<2.9.14:common.html
 <div>text </div>
+<===> libxml2>=2.9.14:common.html
+<div>text &lt;[endif]--&gt;</div>
 <===>
 
 
 <===> fragment.html
 <div>text <!--[if IE]> <!-- IE specific --> comment <[endif]--></div>
-<===> common.html
+<===> libxml2<2.9.14:common.html
 <div>text  comment </div>
+<===> libxml2>=2.9.14:common.html
+<div>text  comment &lt;[endif]--&gt;</div>
 <===>
 
 
@@ -451,14 +459,22 @@ text
 
 <===> fragment.html
 <div>text <![if !IE]> comment <![endif]></div>
-<===> common.html
+<===> libxml2>2.9.14:common.html
+<div>text  comment </div>
+<===> libxml2==2.9.14:common.html
+<div>text &lt;![if !IE]&gt; comment &lt;![endif]&gt;</div>
+<===> libxml2<2.9.14:common.html
 <div>text  comment </div>
 <===>
 
 
 <===> fragment.html
 <div>text <![ if !IE]> comment <![endif]></div>
-<===> common.html
+<===> libxml2>2.9.14:common.html
+<div>text  comment </div>
+<===> libxml2==2.9.14:common.html
+<div>text &lt;![ if !IE]&gt; comment &lt;![endif]&gt;</div>
+<===> libxml2<2.9.14:common.html
 <div>text  comment </div>
 <===>
 

--- a/spec/support/hrx.cr
+++ b/spec/support/hrx.cr
@@ -1,5 +1,15 @@
 require "spec"
 require "hrx"
+require "semantic_version"
+
+lib LibXML
+  $xmlParserVersion : LibC::Char*
+end
+
+private def libxml_version
+  number = String.new(LibXML.xmlParserVersion).to_i
+  "#{number // 10_000}.#{number % 10_000 // 100}.#{number % 100}"
+end
 
 def run_hrx_samples_dir(dir)
   Dir.each_child(dir) do |child|
@@ -44,21 +54,49 @@ def run_hrx_samples(archive_file, policies, *, relative_to = __DIR__)
   end
 end
 
+private LIBXML2_VERSION = SemanticVersion.parse(libxml_version)
+
+def test_libxml_version(path)
+  md = path.match(/^libxml2(<|<=|==|>=|>)([^:]+)/) || return path
+
+  comparator = md[1]
+  version = SemanticVersion.parse(md[2])
+
+  case comparator
+  when "<"
+    return unless LIBXML2_VERSION < version
+  when "<="
+    return unless LIBXML2_VERSION <= version
+  when "=="
+    return unless LIBXML2_VERSION == version
+  when ">="
+    return unless LIBXML2_VERSION >= version
+  when ">"
+    return unless LIBXML2_VERSION > version
+  else
+    fail "Unrecgonized libxml2 version constraint: #{comparator.inspect} in #{path}"
+  end
+
+  path.byte_slice((md.byte_end + 1)..)
+end
+
 def it_hrx_sample(policies, source, expected, archive_file)
   extension = File.extname(expected.path)
-  basename = File.basename(expected.path, extension)
+  path = test_libxml_version(expected.path) || return
+  basename = File.basename(path, extension)
+
   found_policy = true
   policy = policies.fetch(basename) { found_policy = false; nil }
   if !policy && found_policy
-    pending "#{File.dirname(source.path)} #{basename}"
+    pending "#{File.dirname(source.path)} #{expected.path}"
     return
   end
 
-  it "#{File.dirname(source.path)} (#{basename})" do
+  it "#{File.dirname(source.path)} (#{expected.path})" do
     if p = policy
       assert_sanitize(p, source, expected, file: archive_file)
     else
-      raise "Unregistered policy #{basename}"
+      fail "Unregistered policy #{basename}"
     end
   end
 end

--- a/spec/text_policy.hrx
+++ b/spec/text_policy.hrx
@@ -47,10 +47,14 @@ Lorem ipsum dolor sit amet
 <==>
 
 
-# Pending because libxml2 behaviour changed in 2.9.13 (https://gitlab.gnome.org/GNOME/libxml2/-/issues/339)
-<==> pending:html-special-chars/fragment.html
+# libxml2 behaviour changed in 2.9.13 (https://gitlab.gnome.org/GNOME/libxml2/-/issues/339)
+<==> html-special-chars/fragment.html
 <<foo>script>
-<==> pending:html-special-chars/text.html
+<==> libxml2>2.9.13:html-special-chars/text.html
+&lt;script&gt;
+<==> libxml2==2.9.13:html-special-chars/text.html
+script&gt;
+<==> libxml2<2.9.13:html-special-chars/text.html
 &lt;script&gt;
 <==>
 


### PR DESCRIPTION
Alternatively, we could define multiple outputs and expect one of them to match. The version restrictions are a bit more strict (not sure if that's necessary, though) and weren't too dificult to implement.